### PR TITLE
Remove empty application tag in the AndroidManifest.xml file

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -22,7 +22,4 @@
   ~ SOFTWARE.
   -->
 
-<manifest package="io.karn.sentry">
-
-    <application />
-</manifest>
+<manifest package="io.karn.sentry" />


### PR DESCRIPTION
**Issue**: #2

**Proposed changes**:
- Remove empty application tag in the `AndroidManifest.xml` file.